### PR TITLE
[minor] hide chart area when mandatory filters are not set

### DIFF
--- a/frappe/public/js/frappe/views/reports/query_report.js
+++ b/frappe/public/js/frappe/views/reports/query_report.js
@@ -411,7 +411,7 @@ frappe.views.QueryReport = Class.extend({
 			if(v) filters[f.df.fieldname] = v;
 		})
 		if(raise && mandatory_fields.length) {
-			this.chart_area.toggle(true);
+			this.chart_area.hide();
 			this.wrapper.find(".waiting-area").empty().toggle(false);
 			this.wrapper.find(".no-report-area").html(__("Please set filters")).toggle(true);
 			if(raise) {


### PR DESCRIPTION
- using this.chart_area.hide() instead of this.chart_area.toggle(true);